### PR TITLE
UTF-8 Support

### DIFF
--- a/src/main/java/sx/blah/discord/DiscordClient.java
+++ b/src/main/java/sx/blah/discord/DiscordClient.java
@@ -212,7 +212,7 @@ public final class DiscordClient {
 
             try {
                 String response = Requests.POST.makeRequest(DiscordEndpoints.CHANNELS + channelID + "/messages",
-                        new StringEntity("{\"content\":\"" + content + "\",\"mentions\":[]}"),
+                        new StringEntity("{\"content\":\"" + content + "\",\"mentions\":[]}","UTF-8"),
                         new BasicNameValuePair("authorization", token),
                         new BasicNameValuePair("content-type", "application/json"));
 


### PR DESCRIPTION
Adds UTF-8 encoding to messages sent from the client. Previously, messages like ヽ༼■ل͜■༽ﾉ rendered as ????????, and what's Discord support without Donger support.

May need to add UTF-8 support elsewhere, I'm not sure if account names/passwords/etc can be in UTF-8 encoding, but the HTTP request generated won't be encoded properly without this setting.

Also, you need to set the JVM to UTF-8 mode to work with UTF-8 strings. I use the VM argument
```
-Dfile.encoding=UTF-8
```
in my eclipse run configuration.